### PR TITLE
#92 state the current library version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](https://github.com/yegor256/colorizejs/blob/master/LICENSE.txt)
 [![NPM version](https://badge.fury.io/js/colorizejs.svg)](https://badge.fury.io/js/colorizejs)
 
+The current version of the library is `1.2.0`,
+  the full list is on the
+  [releases](https://github.com/yegor256/colorizejs/releases) page.
+
 It's a simple [jQuery](https://jquery.com/) plugin
   to colorize data elements according to their values:
 


### PR DESCRIPTION
README #92 noted that the current version of the library was nowhere in the prose. The only signal was the NPM badge, which renders an image rather than a value readers can copy or grep for.

Add one short paragraph directly under the badge row stating `1.2.0` and linking to the releases page. The text matches the version pinned in the CDN block below it and the latest tag on NPM. No other content is touched.

`npx gulp` runs the existing JSHint pass on `src/colorizejs.js` plus the Jasmine spec — 2 tests, 8 assertions, no failures. `npx markdownlint-cli2 README.md` reports 0 errors. The eight pre-existing JSHint warnings on the helper block at `src/colorizejs.js:34-63` are untouched here and are tracked separately in #120.

Closes #92
