### PR TITLE
#120: remove four unused helper functions

### DIFF
--- a/src/colorizejs.js
+++ b/src/colorizejs.js
@@ -31,34 +31,3 @@ $.fn.colorize = function(colors) {
   }
   return this;
 };
-function getSortedThresholds(colors) {
-	return Object.keys(colors)
-		.map((key) => parseInt(key))
-		.sort((a, b) => b - a);
-}
-function findAndApplyColor(element, data, thresholds, colors) {
-	for (let i = 0; i < thresholds.length; i++) {
-		const threshold = thresholds[i];
-		if (data >= threshold) {
-			const colorValue = colors[threshold];
-			applyColor(element, colorValue);
-			return colorValue;
-		}
-	}
-	return '';
-}
-function applyColor(element, colorValue) {
-	if (colorValue.startsWith('.')) {
-		element.addClass(colorValue.substring(1));
-	} else {
-		element.css('color', colorValue);
-	}
-}
-function cleanupUnusedColors(element, thresholds, colors, appliedColor) {
-	for (let i = 0; i < thresholds.length; i++) {
-		const colorValue = colors[thresholds[i]];
-		if (appliedColor !== colorValue && colorValue.startsWith('.')) {
-			element.removeClass(colorValue.substring(1));
-		}
-	}
-}


### PR DESCRIPTION
Closes #120.

## Problem

`src/colorizejs.js` defined four helper functions — `getSortedThresholds`, `findAndApplyColor`, `applyColor`, `cleanupUnusedColors` — that were never called from the source, the spec, or the build artifacts. The only exported entry point, `$.fn.colorize`, implements the colorization end to end on its own and references none of them. A grep for the helper names across the repository returns only their definitions (plus the helpers calling one another).

They were an unfinished refactor committed alongside the original loop: they duplicate the live logic, drift in style (arrow functions, `let`/`const` vs the surrounding `var`), and inflate the minified bundle shipped from `dist/`.

## Fix

Remove the four functions and keep `$.fn.colorize` as the single implementation, so only one path remains.

## Verification

`npx gulp` (clean → compile → test) is green: 2 tests, 8 assertions, 0 failures. As a bonus, jshint now reports **zero** warnings on the file — the previous eight came from the dead ES6 syntax that was just removed.